### PR TITLE
Uniqueness on segments

### DIFF
--- a/lib/intercom_stats/intercom/segment.ex
+++ b/lib/intercom_stats/intercom/segment.ex
@@ -4,9 +4,13 @@ defmodule IntercomStats.Intercom.Segment do
   alias IntercomStats.Intercom.Segment
   alias IntercomStats.Intercom.Conversation
 
+  @primary_key{:id, :string, []}
   schema "segments" do
     field :name, :string
+    field :person_type, :string
     has_many :conversations, Conversation
+
+    timestamps()
   end
 
   @doc false

--- a/priv/repo/migrations/20170913073354_create_segments.exs
+++ b/priv/repo/migrations/20170913073354_create_segments.exs
@@ -2,8 +2,12 @@ defmodule IntercomStats.Repo.Migrations.CreateSegments do
   use Ecto.Migration
 
   def change do
-    create table(:segments) do
+    create table(:segments, primary_key: false) do
+      add :id, :string, primary_key: true
       add :name, :string
+      add :person_type, :string
+
+      timestamps()
     end
   end
 end

--- a/test/intercom/segments_test.exs
+++ b/test/intercom/segments_test.exs
@@ -10,4 +10,11 @@ defmodule IntercomStats.SegmentsTest do
 
     assert Enum.count(Repo.all(Segment)) == 2
   end
+
+  test "only unique segments are saved" do
+    Segments.save_from_api
+    Segments.save_from_api
+
+    assert Enum.count(Repo.all(Segment)) == 2
+  end
 end


### PR DESCRIPTION
### This is based on the Circle CI branch

- [x] Change the Tag `Id` from ID to String
- [x] Add timestamps
- [x] Add person_type (this is the type of segment given by intercom)
- [x] Change insert_all to insert and update

Segments might be updated in Intercom, if they are they should be updated in our local db as well.