### PR TITLE
Needs custom compile to not build brunch on heroku

### DIFF
--- a/compile
+++ b/compile
@@ -1,0 +1,7 @@
+cd $phoenix_dir
+
+mix "${phoenix_ex}.digest"
+
+if mix help "${phoenix_ex}.digest.clean" 1>/dev/null 2>&1; then
+  mix "${phoenix_ex}.digest.clean"
+fi


### PR DESCRIPTION
https://elements.heroku.com/buildpacks/mlankenau/heroku-buildpack-phoenix-webpack
If I'm understanding correctly you only need to add a compile file in the root and that will override the standard compile of https://github.com/gjaldon/heroku-buildpack-phoenix-static/blob/master/compile
which we use to build our css and js.